### PR TITLE
Implement front-end vinyl UI mock

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,54 +1,66 @@
-// src/App.js
-import React from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import Login from "./components/Login.jsx";
-import Callback from "./components/Callback.jsx";
-import SwipeView from "./components/SwipeView.jsx";
-import Crate from "./components/Crate.jsx";
-import Shelf from "./components/Shelf.jsx";
-import ProtectedRoute from "./components/ProtectedRoute.jsx";
-import { AuthProvider } from "./contexts/AuthContext.jsx";
-import { CrateProvider } from "./contexts/CrateContext.jsx";
-import { ShelfProvider } from "./contexts/ShelfContext.jsx";
+import { useState } from 'react';
+import VinylPlayer from './components/VinylPlayer.jsx';
+import GenreFilter from './components/GenreFilter.jsx';
+import Crate from './components/Crate.jsx';
+import PlaylistModal from './components/PlaylistModal.jsx';
+import { mockSongs } from './data/mockSongs.js';
 
 function App() {
+  const [currentSong, setCurrentSong] = useState(mockSongs[0]);
+  const [selectedGenre, setSelectedGenre] = useState(null);
+  const [crate, setCrate] = useState([]);
+  const [showModal, setShowModal] = useState(false);
+
+  const addToCrate = (song) => {
+    setCrate((prev) => (prev.find((s) => s.id === song.id) ? prev : [...prev, song]));
+  };
+
+  const removeFromCrate = (id) => {
+    setCrate((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  const clearCrate = () => setCrate([]);
+
+  const handleConfirm = (name) => {
+    const count = crate.length;
+    clearCrate();
+    setShowModal(false);
+    alert(`Added ${count} songs to "${name}" playlist!`);
+  };
+
   return (
-    <AuthProvider>
-      <CrateProvider>
-        <ShelfProvider>
-          <Router>
-            <Routes>
-              <Route path="/" element={<Login />} />
-              <Route path="/callback" element={<Callback />} />
-              <Route
-                path="/swipe"
-                element={
-                  <ProtectedRoute>
-                    <SwipeView />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/crate"
-                element={
-                  <ProtectedRoute>
-                    <Crate />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/shelf"
-                element={
-                  <ProtectedRoute>
-                    <Shelf />
-                  </ProtectedRoute>
-                }
-              />
-            </Routes>
-          </Router>
-        </ShelfProvider>
-      </CrateProvider>
-    </AuthProvider>
+    <div className="min-h-screen p-6 bg-black text-white flex flex-col items-center gap-8">
+      <h1 className="text-2xl font-bold">Vinyl Player</h1>
+
+      {!selectedGenre && (
+        <VinylPlayer
+          song={currentSong}
+          onGenreSelect={(g) => setSelectedGenre(g)}
+          onAddToCrate={addToCrate}
+        />
+      )}
+
+      {selectedGenre && (
+        <GenreFilter
+          genre={selectedGenre}
+          songs={mockSongs}
+          onSelectSong={(s) => {
+            setCurrentSong(s);
+            setSelectedGenre(null);
+          }}
+          onClose={() => setSelectedGenre(null)}
+        />
+      )}
+
+      <Crate crate={crate} onRemove={removeFromCrate} onProceed={() => setShowModal(true)} />
+
+      {showModal && (
+        <PlaylistModal
+          onConfirm={handleConfirm}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
   );
 }
 

--- a/src/components/Crate.jsx
+++ b/src/components/Crate.jsx
@@ -1,54 +1,35 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { CrateContext } from '../contexts/CrateContext.jsx';
-import { AuthContext } from '../contexts/AuthContext.jsx';
-import { addTracksToPlaylist, getUserPlaylists } from '../SpotifyService.js';
+import React from 'react';
 
-const Crate = () => {
-  const { crate, clearCrate } = useContext(CrateContext);
-  const { token } = useContext(AuthContext);
-  const [playlists, setPlaylists] = useState([]);
-  const [selected, setSelected] = useState('');
-
-  useEffect(() => {
-    if (token) {
-      getUserPlaylists(token).then((p) => setPlaylists(p.items || []));
-    }
-  }, [token]);
-
-  const handleSend = async () => {
-    if (!selected) return;
-    const uris = crate.map((track) => track.uri);
-    await addTracksToPlaylist(token, selected, uris);
-    clearCrate();
-    alert('Tracks added!');
-  };
-
+const Crate = ({ crate, onRemove, onProceed }) => {
   return (
-    <div className="p-10 text-white">
-      <h1 className="text-2xl font-bold mb-6">Your Crate</h1>
-      {crate.map(track => (
-        <div key={track.id} className="mb-4">
-          <p>{track.name} — {track.artists[0].name}</p>
-        </div>
-      ))}
-      {crate.length > 0 && (
-        <div className="mt-4">
-          <select
-            className="bg-gray-700 text-white p-2 rounded mr-2"
-            value={selected}
-            onChange={(e) => setSelected(e.target.value)}
+    <div className="p-4 text-white w-full">
+      <h3 className="text-xl font-bold mb-2">Your Crate</h3>
+      {crate.length === 0 && <p>(No songs added yet)</p>}
+      <ul className="mb-4">
+        {crate.map((song) => (
+          <li
+            key={song.id}
+            className="flex justify-between items-center mb-1"
           >
-            <option value="">Select playlist</option>
-            {playlists.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
-          <button onClick={handleSend} className="bg-blue-600 px-4 py-2 rounded hover:bg-blue-700">
-            Send to Playlist
-          </button>
-        </div>
+            <span>
+              {song.title} — {song.artist}
+            </span>
+            <button
+              onClick={() => onRemove(song.id)}
+              className="text-red-400 hover:text-red-200"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      {crate.length > 0 && (
+        <button
+          onClick={onProceed}
+          className="bg-blue-600 px-4 py-1 rounded hover:bg-blue-700"
+        >
+          Add to Playlist
+        </button>
       )}
     </div>
   );

--- a/src/components/GenreFilter.jsx
+++ b/src/components/GenreFilter.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const GenreFilter = ({ genre, songs, onSelectSong, onClose }) => {
+  const filtered = songs.filter((s) => s.genre.includes(genre));
+
+  return (
+    <div className="p-4 text-white w-full">
+      <h3 className="text-xl font-bold mb-4 text-center">Genre: {genre}</h3>
+      <div className="grid grid-cols-2 gap-4">
+        {filtered.map((song) => (
+          <div
+            key={song.id}
+            className="cursor-pointer text-center"
+            onClick={() => onSelectSong(song)}
+          >
+            <img
+              src={song.image}
+              alt={song.title}
+              className="rounded-full w-32 h-32 object-cover mx-auto"
+            />
+            <p className="mt-2 text-sm">
+              <strong>{song.title}</strong>
+              <br />
+              {song.artist}
+            </p>
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={onClose}
+        className="mt-4 bg-gray-700 px-3 py-1 rounded"
+      >
+        Back
+      </button>
+    </div>
+  );
+};
+
+export default GenreFilter;

--- a/src/components/PlaylistModal.jsx
+++ b/src/components/PlaylistModal.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+const PlaylistModal = ({ onConfirm, onClose }) => {
+  const [name, setName] = useState('');
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-10">
+      <div className="bg-gray-800 p-6 rounded w-80">
+        <h3 className="text-xl font-bold mb-4 text-white">Add to Playlist</h3>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Playlist name"
+          className="w-full p-2 mb-4 text-black"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-600 text-white rounded"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => name && onConfirm(name)}
+            className="px-3 py-1 bg-blue-600 text-white rounded"
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlaylistModal;

--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+
+const VinylPlayer = ({ song, onGenreSelect, onAddToCrate }) => {
+  const [playing, setPlaying] = useState(false);
+  const [flipped, setFlipped] = useState(false);
+
+  const togglePlay = (e) => {
+    e.stopPropagation();
+    setPlaying((p) => !p);
+  };
+
+  return (
+    <div className="bg-gray-800 p-4 rounded w-80 mx-auto">
+      <div
+        className="relative w-full aspect-square perspective cursor-pointer"
+        onClick={() => setFlipped(!flipped)}
+      >
+        <div
+          className={`absolute inset-0 transition-transform duration-500 preserve-3d ${
+            flipped ? 'rotate-y-180' : ''
+          }`}
+        >
+          <div className="absolute inset-0 backface-hidden flex flex-col items-center justify-center gap-2">
+            <img
+              src={song.image}
+              alt={song.title}
+              className={`rounded-full w-48 h-48 object-cover ${
+                playing ? 'animate-spin-slow' : ''
+              }`}
+              onClick={togglePlay}
+            />
+            <button
+              onClick={togglePlay}
+              className="bg-blue-600 text-white px-4 py-1 rounded"
+            >
+              {playing ? 'Pause' : 'Play'}
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddToCrate(song);
+              }}
+              className="bg-purple-600 text-white px-2 py-1 rounded"
+            >
+              Add to Crate
+            </button>
+            <p className="mt-2 text-center">
+              <strong>{song.title}</strong> — {song.artist}
+            </p>
+          </div>
+          <div className="absolute inset-0 backface-hidden rotate-y-180 flex flex-col justify-center items-center p-4 bg-gray-900 text-white gap-2 rounded">
+            <h2 className="text-lg font-bold">{song.artist}</h2>
+            <p className="text-sm mb-2 text-center">{song.bio}</p>
+            <div className="flex flex-wrap gap-2">
+              {song.genre.map((g) => (
+                <button
+                  key={g}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onGenreSelect(g);
+                  }}
+                  className="bg-blue-700 text-xs px-2 py-1 rounded"
+                >
+                  {g}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VinylPlayer;

--- a/src/data/mockSongs.js
+++ b/src/data/mockSongs.js
@@ -1,0 +1,34 @@
+export const mockSongs = [
+  {
+    id: 1,
+    title: 'Scarlet Begonias',
+    artist: 'Grateful Dead',
+    genre: ['psychedelic', 'jam', 'rock'],
+    bio: 'Grateful Dead blended folk, blues, and psychedelia into genre-defining jams.',
+    image: 'https://via.placeholder.com/200?text=Grateful+Dead',
+  },
+  {
+    id: 2,
+    title: "Ain't Life Grand",
+    artist: 'Widespread Panic',
+    genre: ['southern rock', 'jam', 'alt'],
+    bio: 'Southern rockers with deep improvisational roots and high-energy live shows.',
+    image: 'https://via.placeholder.com/200?text=Widespread+Panic',
+  },
+  {
+    id: 3,
+    title: "Truckin'",
+    artist: 'Grateful Dead',
+    genre: ['classic rock', 'jam'],
+    bio: 'Grateful Dead blended folk, blues, and psychedelia into genre-defining jams.',
+    image: 'https://via.placeholder.com/200?text=Truckin',
+  },
+  {
+    id: 4,
+    title: 'Chilly Water',
+    artist: 'Widespread Panic',
+    genre: ['jam', 'southern rock'],
+    bio: 'Southern rockers with deep improvisational roots and high-energy live shows.',
+    image: 'https://via.placeholder.com/200?text=Chilly+Water',
+  },
+];


### PR DESCRIPTION
## Summary
- implement VinylPlayer with play/pause animation
- implement flip for artist info and genre tags
- implement GenreFilter to list songs by genre
- implement Crate to hold song selections
- implement PlaylistModal for playlist mock
- include mock song data
- fix quoting in mockSongs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840710635e4832fa49050e21222e241