### PR TITLE
Add metal platter and controls

### DIFF
--- a/src/components/ThreeDRecord.jsx
+++ b/src/components/ThreeDRecord.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 
@@ -11,6 +11,10 @@ function RecordMesh({ playing }) {
   });
   return (
     <group ref={ref} castShadow>
+      <mesh position={[0, -0.015, 0]} castShadow receiveShadow>
+        <cylinderGeometry args={[1.05, 1.05, 0.05, 64]} />
+        <meshStandardMaterial color="#b0b0b0" metalness={1} roughness={0.3} />
+      </mesh>
       <mesh castShadow receiveShadow>
         <cylinderGeometry args={[1, 1, 0.02, 64]} />
         <meshStandardMaterial color="black" />
@@ -23,7 +27,11 @@ function RecordMesh({ playing }) {
   );
 }
 
-function ThreeDRecord({ playing = false }) {
+function ThreeDRecord({ playing = false, showControls = false, onToggle }) {
+  const [localPlaying, setLocalPlaying] = useState(playing);
+  const isControlled = typeof onToggle === 'function';
+  const isPlaying = isControlled ? playing : localPlaying;
+
   if (typeof document !== 'undefined') {
     const testCanvas = document.createElement('canvas');
     const gl =
@@ -38,21 +46,41 @@ function ThreeDRecord({ playing = false }) {
     }
   }
 
+  const handleToggle = () => {
+    if (isControlled) {
+      onToggle(!playing);
+    } else {
+      setLocalPlaying((p) => !p);
+    }
+  };
+
   return (
-    <Canvas shadows camera={{ position: [0, 2, 4], fov: 50 }}>
-      <ambientLight intensity={0.5} />
-      <directionalLight position={[5, 5, 5]} intensity={0.8} castShadow />
-      <RecordMesh playing={playing} />
-      <mesh
-        rotation={[-Math.PI / 2, 0, 0]}
-        position={[0, -0.011, 0]}
-        receiveShadow
-      >
-        <planeGeometry args={[5, 5]} />
-        <meshStandardMaterial color="#777" />
-      </mesh>
-      <OrbitControls />
-    </Canvas>
+    <div>
+      <Canvas shadows camera={{ position: [0, 2, 4], fov: 50 }}>
+        <ambientLight intensity={0.5} />
+        <directionalLight position={[5, 5, 5]} intensity={0.8} castShadow />
+        <RecordMesh playing={isPlaying} />
+        <mesh
+          rotation={[-Math.PI / 2, 0, 0]}
+          position={[0, -0.011, 0]}
+          receiveShadow
+        >
+          <planeGeometry args={[5, 5]} />
+          <meshStandardMaterial color="#777" />
+        </mesh>
+        <OrbitControls />
+      </Canvas>
+      {showControls && (
+        <div className="text-center mt-2">
+          <button
+            onClick={handleToggle}
+            className="bg-blue-600 text-white px-2 py-1 rounded"
+          >
+            {isPlaying ? 'Stop' : 'Start'}
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- make the platter base a metallic cylinder
- optionally show a Start/Stop button inside `ThreeDRecord`
- keep ambient and directional lighting for realism

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684081005a24832f96bc43617df0579c