### PR TITLE
Add photorealistic record player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Local Netlify folder
 .netlify
+node_modules
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vinylswipe",
       "version": "1.0.0",
       "dependencies": {
+        "@react-spring/three": "^9.6.1",
         "@react-three/drei": "^9.86.4",
         "@react-three/fiber": "^8.13.5",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "node node_modules/vite/bin/vite.js preview"
   },
   "dependencies": {
+    "@react-spring/three": "^9.6.1",
     "@react-three/drei": "^9.86.4",
     "@react-three/fiber": "^8.13.5",
     "react": "^18.2.0",

--- a/src/components/ControlOverlay.jsx
+++ b/src/components/ControlOverlay.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Html } from '@react-three/drei';
+
+export default function ControlOverlay({ playing, onPlayPause, onView, onAdd }) {
+  return (
+    <Html position={[0, 2.5, 0]} center>
+      <div className="flex gap-2">
+        <button onClick={onPlayPause} className="bg-blue-600 text-white px-2 py-1 rounded">
+          {playing ? '⏸ Pause' : '▶️ Play'}
+        </button>
+        <button onClick={onView} className="bg-gray-700 text-white px-2 py-1 rounded">
+          View Album
+        </button>
+        <button onClick={onAdd} className="bg-purple-600 text-white px-2 py-1 rounded">
+          Add
+        </button>
+      </div>
+    </Html>
+  );
+}

--- a/src/components/FlippableAlbum.jsx
+++ b/src/components/FlippableAlbum.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+export default function FlippableAlbum({ song, onAddToCrate = () => {}, onGenreClick = () => {} }) {
+  const [flipped, setFlipped] = useState(false);
+
+  const handleGenreClick = (g, e) => {
+    e.stopPropagation();
+    onGenreClick(g);
+  };
+
+  const handleAdd = (e) => {
+    e.stopPropagation();
+    onAddToCrate(song);
+  };
+
+  return (
+    <div className="w-full aspect-square cursor-pointer" style={{ perspective: '1000px' }} onClick={() => setFlipped(!flipped)}>
+      <div
+        className={`relative w-full h-full transition-transform duration-500 ${flipped ? 'rotate-y-180' : ''}`}
+        style={{ transformStyle: 'preserve-3d' }}
+      >
+        <div className="absolute inset-0" style={{ backfaceVisibility: 'hidden' }}>
+          <img src={song.image} alt={song.title} className="w-full h-full object-cover rounded shadow-lg" />
+        </div>
+        <div
+          className="absolute inset-0 bg-gray-900 text-white p-4 rounded shadow-lg flex flex-col justify-between rotate-y-180"
+          style={{ backfaceVisibility: 'hidden' }}
+        >
+          <div>
+            <h2 className="text-lg font-bold">{song.artist}</h2>
+            <p className="text-sm mb-2">{song.title}</p>
+            <p className="text-xs mb-2">{song.bio}</p>
+            <div className="flex flex-wrap gap-2 mb-2">
+              {song.genre.map((g) => (
+                <button key={g} onClick={(e) => handleGenreClick(g, e)} className="bg-blue-700 px-2 py-1 text-xs rounded">
+                  {g}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button onClick={handleAdd} className="bg-purple-600 hover:bg-purple-700 text-white px-2 py-1 rounded mt-2">
+            Add to Crate
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecordPlayerModel.jsx
+++ b/src/components/RecordPlayerModel.jsx
@@ -1,0 +1,118 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useTexture, Html } from '@react-three/drei';
+import { useSpring, animated } from '@react-spring/three';
+
+function Vinyl({ album, playing, lifted, showBack, onFlip, onGenreSelect }) {
+  const group = useRef();
+  const labelTexture = useTexture(album.coverUrl);
+
+  const { position, rotation } = useSpring({
+    position: lifted ? [0, 2, 0] : [0, 0, 0],
+    rotation: [0, showBack ? Math.PI : 0, 0],
+    config: { mass: 1, tension: 170, friction: 26 },
+  });
+
+  useFrame(() => {
+    if (playing && group.current && !lifted) {
+      group.current.rotation.y += 0.02;
+    }
+  });
+
+  return (
+    <animated.group ref={group} position={position} rotation={rotation} onClick={onFlip} castShadow>
+      <mesh rotation={[Math.PI / 2, 0, 0]} castShadow receiveShadow>
+        <cylinderGeometry args={[1.5, 1.5, 0.05, 64]} />
+        <meshStandardMaterial color="black" />
+      </mesh>
+      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
+        <cylinderGeometry args={[0.4, 0.4, 0.02, 32]} />
+        <meshBasicMaterial map={labelTexture} />
+      </mesh>
+      {showBack && (
+        <Html rotation={[Math.PI / 2, 0, 0]} position={[0, 0.1, 0]} transform>
+          <div className="bg-black bg-opacity-80 text-white p-2 rounded w-40 text-xs text-center">
+            <p className="font-bold mb-1">{album.artist}</p>
+            <p className="mb-2">{album.bio}</p>
+            <div className="flex flex-wrap gap-1 justify-center">
+              {album.genre.map((g) => (
+                <button
+                  key={g}
+                  onClick={() => onGenreSelect(g)}
+                  className="bg-blue-700 px-2 py-0.5 rounded"
+                >
+                  {g}
+                </button>
+              ))}
+            </div>
+          </div>
+        </Html>
+      )}
+    </animated.group>
+  );
+}
+
+export default function RecordPlayerModel({ album, playing, lifted, showBack, onFlip, onGenreSelect }) {
+  const knobRef = useRef();
+  const [knob, setKnob] = useState(0);
+  const dragging = useRef(false);
+
+  useFrame(() => {
+    if (knobRef.current) {
+      knobRef.current.rotation.y = knob;
+    }
+  });
+
+  const onPointerDown = (e) => {
+    e.stopPropagation();
+    dragging.current = true;
+  };
+  const onPointerUp = () => {
+    dragging.current = false;
+  };
+  const onPointerMove = (e) => {
+    if (dragging.current) {
+      setKnob((k) => Math.min(Math.PI / 2, Math.max(-Math.PI / 2, k + e.movementX * 0.01)));
+    }
+  };
+
+  return (
+    <group>
+      <mesh position={[0, -1.5, 0]} receiveShadow>
+        <boxGeometry args={[4, 0.3, 4]} />
+        <meshStandardMaterial color="#8B5E3C" />
+      </mesh>
+      <mesh receiveShadow castShadow>
+        <boxGeometry args={[3, 0.3, 2]} />
+        <meshStandardMaterial color="#555" metalness={0.5} roughness={0.6} />
+      </mesh>
+      <mesh position={[0, 0.18, 0]} castShadow receiveShadow>
+        <cylinderGeometry args={[1.6, 1.6, 0.1, 64]} />
+        <meshStandardMaterial color="#888" metalness={1} roughness={0.4} />
+      </mesh>
+      <mesh position={[-0.8, 0.05, 0.8]} rotation={[0, 0, -0.3]} castShadow>
+        <cylinderGeometry args={[0.02, 0.02, 1.2, 16]} />
+        <meshStandardMaterial color="#b0b0b0" metalness={1} roughness={0.3} />
+      </mesh>
+      <mesh
+        ref={knobRef}
+        position={[1, 0.2, 0.8]}
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+        onPointerMove={onPointerMove}
+        castShadow
+      >
+        <cylinderGeometry args={[0.1, 0.1, 0.05, 32]} />
+        <meshStandardMaterial color="#333" metalness={0.3} />
+      </mesh>
+      <Vinyl
+        album={album}
+        playing={playing}
+        lifted={lifted}
+        showBack={showBack}
+        onFlip={onFlip}
+        onGenreSelect={onGenreSelect}
+      />
+    </group>
+  );
+}

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -1,135 +1,44 @@
-import React, { useRef, useState } from 'react';
-import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import { OrbitControls, useTexture } from '@react-three/drei';
+import React, { useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import RecordPlayerModel from './RecordPlayerModel.jsx';
+import ControlOverlay from './ControlOverlay.jsx';
 
-function Vinyl({ albumCoverUrl, playing, flipped, onFlip }) {
-  const ref = useRef();
-  const texture = useTexture(albumCoverUrl);
-  useFrame(() => {
-    if (playing && !flipped && ref.current) {
-      ref.current.rotation.y += 0.01;
-    }
-  });
-
-  const handlePointerDown = (e) => {
-    e.stopPropagation();
-    onFlip();
-  };
-
-  return (
-    <group ref={ref} castShadow onPointerDown={handlePointerDown}>
-      <mesh rotation={[Math.PI / 2, 0, 0]} castShadow receiveShadow>
-        <cylinderGeometry args={[1, 1, 0.02, 64]} />
-        <meshStandardMaterial color="black" />
-      </mesh>
-      {/* top label */}
-      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.011, 0]}>
-        <cylinderGeometry args={[0.3, 0.3, 0.001, 32]} />
-        <meshStandardMaterial map={texture} />
-      </mesh>
-      {/* bottom label */}
-      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, -0.011, 0]}>
-        <cylinderGeometry args={[0.3, 0.3, 0.001, 32]} />
-        <meshStandardMaterial color="#222" />
-      </mesh>
-    </group>
-  );
-}
-
-function Tonearm() {
-  return (
-    <group>
-      <mesh position={[-0.8, 0.05, 0.8]} rotation={[0, 0, -0.3]} castShadow>
-        <cylinderGeometry args={[0.02, 0.02, 1.2, 16]} />
-        <meshStandardMaterial color="#b0b0b0" metalness={1} roughness={0.3} />
-      </mesh>
-      <mesh position={[-0.3, 0.02, 0.2]} rotation={[0, 0, -0.3]} castShadow>
-        <boxGeometry args={[0.05, 0.05, 0.1]} />
-        <meshStandardMaterial color="silver" metalness={1} roughness={0.2} />
-      </mesh>
-    </group>
-  );
-}
-
-function Turntable({ children }) {
-  const wood = '#654321';
-  return (
-    <group>
-      <mesh receiveShadow castShadow>
-        <boxGeometry args={[3, 0.3, 2]} />
-        <meshStandardMaterial color={wood} />
-      </mesh>
-      <mesh position={[0, 0.18, 0]} castShadow receiveShadow>
-        <cylinderGeometry args={[1.1, 1.1, 0.1, 64]} />
-        <meshStandardMaterial color="#888" metalness={1} roughness={0.4} />
-      </mesh>
-      {children}
-      <Tonearm />
-    </group>
-  );
-}
-
-function InfoPanel({ artistInfo }) {
-  const { name, title, genres, bio } = artistInfo || {};
-  return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center bg-gray-900 bg-opacity-80 text-white p-4 rounded">
-      <h2 className="text-lg font-bold mb-1">{name}</h2>
-      <p className="text-sm italic mb-2">{title}</p>
-      <div className="flex flex-wrap gap-2 mb-2">
-        {genres && genres.map((g) => (
-          <span key={g} className="bg-blue-700 text-xs px-2 py-1 rounded">
-            {g}
-          </span>
-        ))}
-      </div>
-      <p className="text-sm text-center">{bio}</p>
-    </div>
-  );
-}
-
-function ThreeDRecordPlayer({ playing: controlledPlaying = false, albumCoverUrl, artistInfo, onToggle }) {
-  const [localPlaying, setLocalPlaying] = useState(controlledPlaying);
+export default function ThreeDRecordPlayer({
+  album,
+  onAddToCrate = () => {},
+  onGenreSelect = () => {},
+  className = '',
+}) {
+  const [playing, setPlaying] = useState(false);
+  const [lifted, setLifted] = useState(false);
   const [flipped, setFlipped] = useState(false);
-  const isControlled = typeof onToggle === 'function';
-  const playing = isControlled ? controlledPlaying : localPlaying;
 
-  const handleToggle = () => {
-    if (isControlled) {
-      onToggle(!controlledPlaying);
-    } else {
-      setLocalPlaying(!localPlaying);
-    }
-  };
-
-  const handleFlip = () => {
-    setFlipped((f) => !f);
-  };
+  const togglePlay = () => setPlaying((p) => !p);
+  const handleView = () => setLifted((v) => !v);
+  const handleFlip = () => setFlipped((f) => !f);
 
   return (
-    <div className="relative w-full h-full">
-      <Canvas shadows camera={{ position: [3, 2, 5], fov: 45 }}>
-        <ambientLight intensity={0.5} />
-        <directionalLight position={[5, 5, 5]} intensity={0.8} castShadow />
-        <Turntable>
-          <Vinyl albumCoverUrl={albumCoverUrl} playing={playing} flipped={flipped} onFlip={handleFlip} />
-        </Turntable>
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.15, 0]} receiveShadow>
-          <planeGeometry args={[10, 10]} />
-          <shadowMaterial transparent opacity={0.3} />
-        </mesh>
-        <OrbitControls />
+    <div className={className}>
+      <Canvas shadows camera={{ position: [0, 5, 8], fov: 50 }}>
+        <ambientLight intensity={0.4} />
+        <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
+        <RecordPlayerModel
+          album={album}
+          playing={playing}
+          lifted={lifted}
+          showBack={flipped}
+          onFlip={handleFlip}
+          onGenreSelect={onGenreSelect}
+        />
+        <ControlOverlay
+          playing={playing}
+          onPlayPause={togglePlay}
+          onView={handleView}
+          onAdd={() => onAddToCrate(album)}
+        />
+        <OrbitControls enablePan={false} />
       </Canvas>
-      {flipped && <InfoPanel artistInfo={artistInfo} />}
-      <div className="absolute bottom-2 left-0 right-0 flex justify-center gap-2">
-        <button onClick={handleToggle} className="bg-blue-600 text-white px-2 py-1 rounded">
-          {playing ? 'Pause' : 'Play'}
-        </button>
-        <button onClick={handleFlip} className="bg-gray-700 text-white px-2 py-1 rounded">
-          Flip
-        </button>
-      </div>
     </div>
   );
 }
-
-export default ThreeDRecordPlayer;

--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -1,73 +1,31 @@
-import React, { useState } from 'react';
-import ThreeDRecord from './ThreeDRecord.jsx';
-const VinylPlayer = ({ song, onGenreSelect, onAddToCrate }) => {
-  const [playing, setPlaying] = useState(false);
-  const [flipped, setFlipped] = useState(false);
+import React from 'react';
+import ThreeDRecordPlayer from './ThreeDRecordPlayer.jsx';
+import FlippableAlbum from './FlippableAlbum.jsx';
 
-  const togglePlay = (e) => {
-    e.stopPropagation();
-    setPlaying((p) => !p);
-  };
-
+export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
   return (
-    <div className="bg-gray-800 p-4 rounded w-80 mx-auto">
-      <div
-        className="relative w-full aspect-square perspective cursor-pointer"
-        onClick={() => setFlipped(!flipped)}
-      >
-        <div
-          className={`absolute inset-0 transition-transform duration-500 preserve-3d ${
-            flipped ? 'rotate-y-180' : ''
-          }`}
-        >
-          <div className="absolute inset-0 backface-hidden flex flex-col items-center justify-center gap-2">
-            <div
-              className="w-48 h-48"
-              onPointerDown={(e) => e.stopPropagation()}
-            >
-              <ThreeDRecord playing={playing} />
-            </div>
-            <button
-              onClick={togglePlay}
-              className="bg-blue-600 text-white px-4 py-1 rounded"
-            >
-              {playing ? 'Pause' : 'Play'}
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddToCrate(song);
-              }}
-              className="bg-purple-600 text-white px-2 py-1 rounded"
-            >
-              Add to Crate
-            </button>
-            <p className="mt-2 text-center">
-              <strong>{song.title}</strong> — {song.artist}
-            </p>
-          </div>
-          <div className="absolute inset-0 backface-hidden rotate-y-180 flex flex-col justify-center items-center p-4 bg-gray-900 text-white gap-2 rounded">
-            <h2 className="text-lg font-bold">{song.artist}</h2>
-            <p className="text-sm mb-2 text-center">{song.bio}</p>
-            <div className="flex flex-wrap gap-2">
-              {song.genre.map((g) => (
-                <button
-                  key={g}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onGenreSelect(g);
-                  }}
-                  className="bg-blue-700 text-xs px-2 py-1 rounded"
-                >
-                  {g}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
+    <div className="flex flex-col md:flex-row items-center justify-center gap-6 p-4">
+      <div className="w-full md:w-2/3 h-[600px]">
+        <ThreeDRecordPlayer
+          className="w-full h-full"
+          album={{
+            title: song.title,
+            artist: song.artist,
+            coverUrl: song.image,
+            bio: song.bio,
+            genre: song.genre,
+          }}
+          onGenreSelect={onGenreSelect}
+          onAddToCrate={() => onAddToCrate(song)}
+        />
+      </div>
+      <div className="w-full md:w-1/3">
+        <FlippableAlbum
+          song={song}
+          onAddToCrate={onAddToCrate}
+          onGenreClick={onGenreSelect}
+        />
       </div>
     </div>
   );
-};
-
-export default VinylPlayer;
+}


### PR DESCRIPTION
## Summary
- add `@react-spring/three` dependency
- ignore build and node files
- build new `RecordPlayerModel` and `ControlOverlay` components
- overhaul `ThreeDRecordPlayer` to include lift and flip animations
- switch `VinylPlayer` to use the new player component
- add flippable album card and enlarge 3D scene

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684086bdb184832f8eb42b86a37334c2