### PR TITLE
Fix mock song image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ npm install
 npm run dev
 ```
 
-If you encounter an error about a missing optional Rollup module when building, delete `node_modules` and `package-lock.json` and reinstall:
+If `npm run build` fails with a message like `Cannot find module @rollup/rollup-linux-x64-gnu`,
+remove `node_modules` and `package-lock.json` then reinstall to ensure the correct
+Rollup binary is downloaded for your platform:
 
 ```bash
 rm -rf node_modules package-lock.json

--- a/src/data/mockSongs.js
+++ b/src/data/mockSongs.js
@@ -1,3 +1,8 @@
+import scarletImg from '../assets/Scarlet.jfif';
+import panicImg from '../assets/wsp.jpg';
+import truckinImg from '../assets/truckin.jpg';
+import chillyImg from '../assets/chillywaterr.jfif';
+
 export const mockSongs = [
   {
     id: 1,
@@ -5,7 +10,7 @@ export const mockSongs = [
     artist: 'Grateful Dead',
     genre: ['psychedelic', 'jam', 'rock'],
     bio: 'Grateful Dead blended folk, blues, and psychedelia into genre-defining jams.',
-    image: '..src/truckin.jpg',
+    image: scarletImg,
   },
   {
     id: 2,
@@ -13,7 +18,7 @@ export const mockSongs = [
     artist: 'Widespread Panic',
     genre: ['southern rock', 'jam', 'alt'],
     bio: 'Southern rockers with deep improvisational roots and high-energy live shows.',
-    image: '../wsp.jpg',
+    image: panicImg,
   },
   {
     id: 3,
@@ -21,7 +26,7 @@ export const mockSongs = [
     artist: 'Grateful Dead',
     genre: ['classic rock', 'jam'],
     bio: 'Grateful Dead blended folk, blues, and psychedelia into genre-defining jams.',
-    image: '../truckin.jpg',
+    image: truckinImg,
   },
   {
     id: 4,
@@ -29,6 +34,7 @@ export const mockSongs = [
     artist: 'Widespread Panic',
     genre: ['jam', 'southern rock'],
     bio: 'Southern rockers with deep improvisational roots and high-energy live shows.',
-    image: '../wsp.jpg',
+    image: chillyImg,
   },
 ];
+


### PR DESCRIPTION
## Summary
- correct file paths for album images used throughout the demo
- clarify how to reinstall rollup's native binary if build fails

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840971a74a0832fa4528d0c1d7d144f