### PR TITLE
Fix asset paths and full-width player

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ npm install
 npm run dev
 ```
 
-If you encounter an error about a missing optional Rollup module when building, delete `node_modules` and `package-lock.json` and reinstall:
+If `npm run build` fails with a message like `Cannot find module @rollup/rollup-linux-x64-gnu`,
+remove `node_modules` and `package-lock.json` then reinstall to ensure the correct
+Rollup binary is downloaded for your platform:
 
 ```bash
 rm -rf node_modules package-lock.json

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen p-6 bg-black text-white flex flex-col items-center gap-8">
+    <div className="min-h-screen w-screen p-6 bg-black text-white flex flex-col items-center gap-8">
       <h1 className="text-2xl font-bold">Vinyl Player</h1>
 
       {!selectedGenre && (

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -19,7 +19,7 @@ export default function ThreeDRecordPlayer({
   const handleFlip = () => setFlipped((f) => !f);
 
   return (
-    <div className={`${className} w-full h-[80vh]`}>
+    <div className={`${className} w-screen h-[80vh]`}>
       <Canvas shadows camera={{ position: [0, 5, 8], fov: 50 }}>
         <ambientLight intensity={0.4} />
         <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />

--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -4,8 +4,8 @@ import FlippableAlbum from './FlippableAlbum.jsx';
 
 export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
   return (
-    <div className="flex flex-col md:flex-row items-center justify-center gap-6 p-4 h-screen">
-      <div className="w-full md:w-2/3 h-full">
+    <div className="flex flex-col md:flex-row items-center justify-center gap-6 p-4 h-screen w-full">
+      <div className="w-full h-full">
         <ThreeDRecordPlayer
           className="w-full h-full"
           album={{

--- a/src/data/mockSongs.js
+++ b/src/data/mockSongs.js
@@ -1,3 +1,8 @@
+import scarletImg from '../assets/Scarlet.jfif';
+import panicImg from '../assets/wsp.jpg';
+import truckinImg from '../assets/truckin.jpg';
+import chillyImg from '../assets/chillywaterr.jfif';
+
 export const mockSongs = [
   {
     id: 1,
@@ -5,7 +10,7 @@ export const mockSongs = [
     artist: 'Grateful Dead',
     genre: ['psychedelic', 'jam', 'rock'],
     bio: 'Grateful Dead blended folk, blues, and psychedelia into genre-defining jams.',
-    image: '..src/truckin.jpg',
+    image: scarletImg,
   },
   {
     id: 2,
@@ -13,7 +18,7 @@ export const mockSongs = [
     artist: 'Widespread Panic',
     genre: ['southern rock', 'jam', 'alt'],
     bio: 'Southern rockers with deep improvisational roots and high-energy live shows.',
-    image: '../wsp.jpg',
+    image: panicImg,
   },
   {
     id: 3,
@@ -21,7 +26,7 @@ export const mockSongs = [
     artist: 'Grateful Dead',
     genre: ['classic rock', 'jam'],
     bio: 'Grateful Dead blended folk, blues, and psychedelia into genre-defining jams.',
-    image: '../truckin.jpg',
+    image: truckinImg,
   },
   {
     id: 4,
@@ -29,6 +34,7 @@ export const mockSongs = [
     artist: 'Widespread Panic',
     genre: ['jam', 'southern rock'],
     bio: 'Southern rockers with deep improvisational roots and high-energy live shows.',
-    image: '../wsp.jpg',
+    image: chillyImg,
   },
 ];
+


### PR DESCRIPTION
## Summary
- use viewport width for the 3D record player container
- reference album art from `src/assets`
- set the top-level layout to span the screen

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840971a74a0832fa4528d0c1d7d144f