### PR TITLE
Add interactive 3D vinyl player component

### DIFF
--- a/src/components/ControlOverlay.jsx
+++ b/src/components/ControlOverlay.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Html } from '@react-three/drei';
 
-export default function ControlOverlay({ playing, onPlayPause, onView, onAdd }) {
+export default function ControlOverlay({
+  playing,
+  onPlayPause,
+  onView,
+  onInfo,
+  onAdd,
+}) {
   return (
     <Html position={[0, 2.5, 0]} center>
       <div className="flex gap-2">
@@ -10,6 +16,9 @@ export default function ControlOverlay({ playing, onPlayPause, onView, onAdd }) 
         </button>
         <button onClick={onView} className="bg-gray-700 text-white px-2 py-1 rounded">
           View Album
+        </button>
+        <button onClick={onInfo} className="bg-gray-700 text-white px-2 py-1 rounded">
+          Album Info
         </button>
         <button onClick={onAdd} className="bg-purple-600 text-white px-2 py-1 rounded">
           Add

--- a/src/components/FlippableAlbum.jsx
+++ b/src/components/FlippableAlbum.jsx
@@ -1,7 +1,15 @@
 import React, { useState } from 'react';
 
-export default function FlippableAlbum({ song, onAddToCrate = () => {}, onGenreClick = () => {} }) {
-  const [flipped, setFlipped] = useState(false);
+export default function FlippableAlbum({
+  song,
+  flipped: flippedProp,
+  onToggle,
+  onAddToCrate = () => {},
+  onGenreClick = () => {},
+}) {
+  const [internalFlipped, setInternalFlipped] = useState(false);
+  const controlled = flippedProp !== undefined;
+  const flipped = controlled ? flippedProp : internalFlipped;
 
   const handleGenreClick = (g, e) => {
     e.stopPropagation();
@@ -13,8 +21,20 @@ export default function FlippableAlbum({ song, onAddToCrate = () => {}, onGenreC
     onAddToCrate(song);
   };
 
+  const handleToggle = () => {
+    if (controlled) {
+      onToggle && onToggle();
+    } else {
+      setInternalFlipped((f) => !f);
+    }
+  };
+
   return (
-    <div className="w-full aspect-square cursor-pointer" style={{ perspective: '1000px' }} onClick={() => setFlipped(!flipped)}>
+    <div
+      className="w-full aspect-square cursor-pointer"
+      style={{ perspective: '1000px' }}
+      onClick={handleToggle}
+    >
       <div
         className={`relative w-full h-full transition-transform duration-500 ${flipped ? 'rotate-y-180' : ''}`}
         style={{ transformStyle: 'preserve-3d' }}

--- a/src/components/RecordPlayerModel.jsx
+++ b/src/components/RecordPlayerModel.jsx
@@ -1,34 +1,43 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useTexture, Html } from '@react-three/drei';
 import { useSpring, animated } from '@react-spring/three';
+import * as THREE from 'three';
 
 function Vinyl({ album, playing, lifted, showBack, onFlip, onGenreSelect }) {
   const group = useRef();
   const labelTexture = useTexture(album.coverUrl);
 
   const { position, rotation } = useSpring({
-    position: lifted ? [0, 2, 0] : [0, 0, 0],
-    rotation: [0, showBack ? Math.PI : 0, 0],
+    position: lifted ? [0, 0, 0] : [0, 1.5, -1],
+    rotation: lifted ? [-Math.PI / 2, 0, 0] : [0, 0, 0],
     config: { mass: 1, tension: 170, friction: 26 },
   });
 
   useFrame(() => {
-    if (playing && group.current && !lifted) {
+    if (playing && group.current && lifted) {
       group.current.rotation.y += 0.02;
     }
   });
 
   return (
     <animated.group ref={group} position={position} rotation={rotation} onClick={onFlip} castShadow>
-      <mesh rotation={[Math.PI / 2, 0, 0]} castShadow receiveShadow>
-        <cylinderGeometry args={[1.5, 1.5, 0.05, 64]} />
-        <meshStandardMaterial color="black" />
+      <mesh>
+        <planeGeometry args={[2, 2]} />
+        <meshBasicMaterial map={labelTexture} side={THREE.DoubleSide} />
       </mesh>
-      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
-        <cylinderGeometry args={[0.4, 0.4, 0.02, 32]} />
-        <meshBasicMaterial map={labelTexture} />
-      </mesh>
+      {lifted && (
+        <group>
+          <mesh rotation={[Math.PI / 2, 0, 0]} castShadow receiveShadow>
+            <cylinderGeometry args={[1.5, 1.5, 0.05, 64]} />
+            <meshStandardMaterial color="black" />
+          </mesh>
+          <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
+            <cylinderGeometry args={[0.4, 0.4, 0.02, 32]} />
+            <meshBasicMaterial map={labelTexture} />
+          </mesh>
+        </group>
+      )}
       {showBack && (
         <Html rotation={[Math.PI / 2, 0, 0]} position={[0, 0.1, 0]} transform>
           <div className="bg-black bg-opacity-80 text-white p-2 rounded w-40 text-xs text-center">
@@ -55,6 +64,7 @@ function Vinyl({ album, playing, lifted, showBack, onFlip, onGenreSelect }) {
 export default function RecordPlayerModel({ album, playing, lifted, showBack, onFlip, onGenreSelect }) {
   const knobRef = useRef();
   const [knob, setKnob] = useState(0);
+  const woodTexture = useTexture('https://images.unsplash.com/photo-1557683316-973673baf926?auto=format&fit=crop&w=1024&q=80');
   const dragging = useRef(false);
 
   useFrame(() => {
@@ -80,7 +90,7 @@ export default function RecordPlayerModel({ album, playing, lifted, showBack, on
     <group>
       <mesh position={[0, -1.5, 0]} receiveShadow>
         <boxGeometry args={[4, 0.3, 4]} />
-        <meshStandardMaterial color="#8B5E3C" />
+        <meshStandardMaterial map={woodTexture} />
       </mesh>
       <mesh receiveShadow castShadow>
         <boxGeometry args={[3, 0.3, 2]} />

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -8,6 +8,7 @@ export default function ThreeDRecordPlayer({
   album,
   onAddToCrate = () => {},
   onGenreSelect = () => {},
+  onInfoToggle = () => {},
   className = '',
 }) {
   const [playing, setPlaying] = useState(false);
@@ -35,6 +36,7 @@ export default function ThreeDRecordPlayer({
           playing={playing}
           onPlayPause={togglePlay}
           onView={handleView}
+          onInfo={onInfoToggle}
           onAdd={() => onAddToCrate(album)}
         />
         <OrbitControls enablePan={false} />

--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ThreeDRecordPlayer from './ThreeDRecordPlayer.jsx';
 import FlippableAlbum from './FlippableAlbum.jsx';
 
 export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
+  const [infoOpen, setInfoOpen] = useState(false);
   return (
     <div className="flex flex-col md:flex-row items-center justify-center gap-6 p-4 h-screen w-full">
       <div className="w-full h-full">
@@ -16,12 +17,15 @@ export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
             genre: song.genre,
           }}
           onGenreSelect={onGenreSelect}
+          onInfoToggle={() => setInfoOpen((o) => !o)}
           onAddToCrate={() => onAddToCrate(song)}
         />
       </div>
       <div className="w-full md:w-1/3 max-w-sm">
         <FlippableAlbum
           song={song}
+          flipped={infoOpen}
+          onToggle={() => setInfoOpen((o) => !o)}
           onAddToCrate={onAddToCrate}
           onGenreClick={onGenreSelect}
         />


### PR DESCRIPTION
## Summary
- expose new `onInfo` button in `ControlOverlay`
- allow controlling flip state of `FlippableAlbum`
- animate album cover onto the turntable and spin in `RecordPlayerModel`
- pass info toggle through `ThreeDRecordPlayer` and `VinylPlayer`
- display player base with remote wood texture

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2fa1908832f8d1bb8e38135b64b