### PR TITLE
Fix FlippableAlbum reference

### DIFF
--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import ThreeDRecordPlayer from './ThreeDRecordPlayer.jsx';
 import AlbumInfoPopup from './AlbumInfoPopup.jsx';
+import FlippableAlbum from './FlippableAlbum.jsx';
 
 export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
   const [infoOpen, setInfoOpen] = useState(false);


### PR DESCRIPTION
## Summary
- import `FlippableAlbum` in `VinylPlayer`

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7f947cc832f96e4a5d32fa6f413