### PR TITLE
Fix missing variable in 3D model

### DIFF
--- a/src/components/RecordPlayerModel.jsx
+++ b/src/components/RecordPlayerModel.jsx
@@ -40,25 +40,6 @@ function Vinyl({ album, playing, lifted, onGenreSelect }) {
         </group>
 
       )}
-      {showBack && (
-        <Html rotation={[Math.PI / 2, 0, 0]} position={[0, 0.1, 0]} transform>
-          <div className="bg-black bg-opacity-80 text-white p-2 rounded w-40 text-xs text-center">
-            <p className="font-bold mb-1">{album.artist}</p>
-            <p className="mb-2">{album.bio}</p>
-            <div className="flex flex-wrap gap-1 justify-center">
-              {album.genre.map((g) => (
-                <button
-                  key={g}
-                  onClick={() => onGenreSelect(g)}
-                  className="bg-blue-700 px-2 py-0.5 rounded"
-                >
-                  {g}
-                </button>
-              ))}
-            </div>
-          </div>
-        </Html>
-      )}
     </animated.group>
   );
 }

--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import ThreeDRecordPlayer from './ThreeDRecordPlayer.jsx';
 import AlbumInfoPopup from './AlbumInfoPopup.jsx';
+import FlippableAlbum from './FlippableAlbum.jsx';
 
 export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
   const [infoOpen, setInfoOpen] = useState(false);


### PR DESCRIPTION
## Summary
- remove leftover `showBack` overlay from `RecordPlayerModel`

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7f947cc832f96e4a5d32fa6f413