### PR TITLE
Add record store environment to 3D scene

### DIFF
--- a/src/components/RecordStoreEnvironment.jsx
+++ b/src/components/RecordStoreEnvironment.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useTexture, Environment } from '@react-three/drei';
+import { mockSongs } from '../data/mockSongs.js';
+
+function VinylRecord({ image, position }) {
+  const texture = useTexture(image);
+  return (
+    <group position={position} rotation={[-Math.PI / 2, 0, 0]}>
+      <mesh receiveShadow castShadow>
+        <cylinderGeometry args={[0.6, 0.6, 0.02, 32]} />
+        <meshStandardMaterial color="black" />
+      </mesh>
+      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.011, 0]}>
+        <circleGeometry args={[0.3, 32]} />
+        <meshBasicMaterial map={texture} />
+      </mesh>
+    </group>
+  );
+}
+
+export default function RecordStoreEnvironment() {
+  const records = mockSongs.slice(0, 4);
+  return (
+    <group>
+      <Environment preset="warehouse" />
+      {/* Floor */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -2.2, 0]} receiveShadow>
+        <planeGeometry args={[20, 20]} />
+        <meshStandardMaterial color="#777" />
+      </mesh>
+      {/* Walls */}
+      <mesh position={[0, 2, -10]} receiveShadow>
+        <boxGeometry args={[20, 8, 0.1]} />
+        <meshStandardMaterial color="#999" />
+      </mesh>
+      <mesh position={[-10, 2, 0]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[20, 8, 0.1]} />
+        <meshStandardMaterial color="#999" />
+      </mesh>
+      <mesh position={[10, 2, 0]} rotation={[0, -Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[20, 8, 0.1]} />
+        <meshStandardMaterial color="#999" />
+      </mesh>
+      {/* Table */}
+      <mesh position={[0, -1.9, 0]} receiveShadow castShadow>
+        <boxGeometry args={[6, 0.3, 4]} />
+        <meshStandardMaterial color="#654321" />
+      </mesh>
+      {/* Simple Shelves */}
+      <mesh position={[-3, 0, -3]} receiveShadow>
+        <boxGeometry args={[0.4, 2, 6]} />
+        <meshStandardMaterial color="#444" />
+      </mesh>
+      <mesh position={[3, 0, -3]} receiveShadow>
+        <boxGeometry args={[0.4, 2, 6]} />
+        <meshStandardMaterial color="#444" />
+      </mesh>
+      {/* Records */}
+      {records.map((song, idx) => (
+        <VinylRecord key={song.id} image={song.image} position={[-1.5 + idx, -1.85, 1]} />
+      ))}
+    </group>
+  );
+}

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import RecordPlayerModel from './RecordPlayerModel.jsx';
+import RecordStoreEnvironment from './RecordStoreEnvironment.jsx';
 import ControlOverlay from './ControlOverlay.jsx';
 
 export default function ThreeDRecordPlayer({
@@ -34,6 +35,7 @@ export default function ThreeDRecordPlayer({
       <Canvas shadows camera={{ position: [0, 5, 8], fov: 50 }}>
         <ambientLight intensity={0.4} />
         <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
+        <RecordStoreEnvironment />
         <RecordPlayerModel
           album={album}
           playing={playing}


### PR DESCRIPTION
## Summary
- add `RecordStoreEnvironment` component providing floor, walls, table and shelves
- display vinyl records using textures from `mockSongs`
- render the environment in `ThreeDRecordPlayer`

## Testing
- `npm run dev` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684739e82860832f88c30523b3a029d2