### PR TITLE
Add immersive vinyl store features

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,67 +1,52 @@
-import { useState } from 'react';
-import VinylPlayer from './components/VinylPlayer.jsx';
-import GenreFilter from './components/GenreFilter.jsx';
-import Crate from './components/Crate.jsx';
-import PlaylistModal from './components/PlaylistModal.jsx';
-import { mockSongs } from './data/mockSongs.js';
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from './contexts/AuthContext.jsx';
+import { CrateProvider } from './contexts/CrateContext.jsx';
+import { ShelfProvider } from './contexts/ShelfContext.jsx';
+import Login from './components/Login.jsx';
+import Callback from './components/Callback.jsx';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
+import SwipeView from './components/SwipeView.jsx';
+import Shelf from './components/Shelf.jsx';
+import CrateView from './components/CrateView.jsx';
 
-function App() {
-  const [currentSong, setCurrentSong] = useState(mockSongs[0]);
-  const [selectedGenre, setSelectedGenre] = useState(null);
-  const [crate, setCrate] = useState([]);
-  const [showModal, setShowModal] = useState(false);
-
-  const addToCrate = (song) => {
-    setCrate((prev) => (prev.find((s) => s.id === song.id) ? prev : [...prev, song]));
-  };
-
-  const removeFromCrate = (id) => {
-    setCrate((prev) => prev.filter((s) => s.id !== id));
-  };
-
-  const clearCrate = () => setCrate([]);
-
-  const handleConfirm = (name) => {
-    const count = crate.length;
-    clearCrate();
-    setShowModal(false);
-    alert(`Added ${count} songs to "${name}" playlist!`);
-  };
-
+export default function App() {
   return (
-    <div className="min-h-screen w-screen p-6 bg-black text-white flex flex-col items-center gap-8">
-      <h1 className="text-2xl font-bold">Vinyl Player</h1>
-
-      {!selectedGenre && (
-        <VinylPlayer
-          song={currentSong}
-          onGenreSelect={(g) => setSelectedGenre(g)}
-          onAddToCrate={addToCrate}
-        />
-      )}
-
-      {selectedGenre && (
-        <GenreFilter
-          genre={selectedGenre}
-          songs={mockSongs}
-          onSelectSong={(s) => {
-            setCurrentSong(s);
-            setSelectedGenre(null);
-          }}
-          onClose={() => setSelectedGenre(null)}
-        />
-      )}
-
-      <Crate crate={crate} onRemove={removeFromCrate} onProceed={() => setShowModal(true)} />
-
-      {showModal && (
-        <PlaylistModal
-          onConfirm={handleConfirm}
-          onClose={() => setShowModal(false)}
-        />
-      )}
-    </div>
+    <BrowserRouter>
+      <AuthProvider>
+        <CrateProvider>
+          <ShelfProvider>
+            <Routes>
+              <Route path="/" element={<Login />} />
+              <Route path="/callback" element={<Callback />} />
+              <Route
+                path="/swipe"
+                element={
+                  <ProtectedRoute>
+                    <SwipeView />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/crate"
+                element={
+                  <ProtectedRoute>
+                    <CrateView />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/shelf"
+                element={
+                  <ProtectedRoute>
+                    <Shelf />
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </ShelfProvider>
+        </CrateProvider>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }
-
-export default App;

--- a/src/DemoApp.jsx
+++ b/src/DemoApp.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import VinylPlayer from './components/VinylPlayer.jsx';
+import GenreFilter from './components/GenreFilter.jsx';
+import Crate from './components/Crate.jsx';
+import PlaylistModal from './components/PlaylistModal.jsx';
+import { mockSongs } from './data/mockSongs.js';
+
+function App() {
+  const [currentSong, setCurrentSong] = useState(mockSongs[0]);
+  const [selectedGenre, setSelectedGenre] = useState(null);
+  const [crate, setCrate] = useState([]);
+  const [showModal, setShowModal] = useState(false);
+
+  const addToCrate = (song) => {
+    setCrate((prev) => (prev.find((s) => s.id === song.id) ? prev : [...prev, song]));
+  };
+
+  const removeFromCrate = (id) => {
+    setCrate((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  const clearCrate = () => setCrate([]);
+
+  const handleConfirm = (name) => {
+    const count = crate.length;
+    clearCrate();
+    setShowModal(false);
+    alert(`Added ${count} songs to "${name}" playlist!`);
+  };
+
+  return (
+    <div className="min-h-screen w-screen p-6 bg-black text-white flex flex-col items-center gap-8">
+      <h1 className="text-2xl font-bold">Vinyl Player</h1>
+
+      {!selectedGenre && (
+        <VinylPlayer
+          song={currentSong}
+          onGenreSelect={(g) => setSelectedGenre(g)}
+          onAddToCrate={addToCrate}
+        />
+      )}
+
+      {selectedGenre && (
+        <GenreFilter
+          genre={selectedGenre}
+          songs={mockSongs}
+          onSelectSong={(s) => {
+            setCurrentSong(s);
+            setSelectedGenre(null);
+          }}
+          onClose={() => setSelectedGenre(null)}
+        />
+      )}
+
+      <Crate crate={crate} onRemove={removeFromCrate} onProceed={() => setShowModal(true)} />
+
+      {showModal && (
+        <PlaylistModal
+          onConfirm={handleConfirm}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/src/SpotifyService.js
+++ b/src/SpotifyService.js
@@ -55,3 +55,15 @@ export async function addTracksToPlaylist(token, playlistId, uris) {
     body: JSON.stringify({ uris }),
   });
 }
+
+export async function createPlaylist(token, userId, name) {
+  const res = await fetch(`${API_BASE}/users/${userId}/playlists`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name, public: false }),
+  });
+  return await res.json();
+}

--- a/src/components/ControlOverlay.jsx
+++ b/src/components/ControlOverlay.jsx
@@ -6,7 +6,8 @@ export default function ControlOverlay({
   onPlayPause,
   onView,
   onInfo,
-  onAdd,
+  onAddCrate,
+  onAddShelf,
 }) {
   return (
     <Html position={[0, 2.5, 0]} center>
@@ -20,8 +21,11 @@ export default function ControlOverlay({
         <button onClick={onInfo} className="bg-gray-700 text-white px-2 py-1 rounded">
           Album Info
         </button>
-        <button onClick={onAdd} className="bg-purple-600 text-white px-2 py-1 rounded">
-          Add
+        <button onClick={onAddCrate} className="bg-blue-600 text-white px-2 py-1 rounded">
+          Add to Crate
+        </button>
+        <button onClick={onAddShelf} className="bg-purple-600 text-white px-2 py-1 rounded">
+          Add to Shelf
         </button>
       </div>
     </Html>

--- a/src/components/CrateView.jsx
+++ b/src/components/CrateView.jsx
@@ -1,0 +1,48 @@
+import React, { useContext, useState } from 'react';
+import { CrateContext } from '../contexts/CrateContext.jsx';
+import { AuthContext } from '../contexts/AuthContext.jsx';
+import Crate from './Crate.jsx';
+import PlaylistModal from './PlaylistModal.jsx';
+import { createPlaylist, addTracksToPlaylist, getProfile } from '../SpotifyService.js';
+
+const CrateView = () => {
+  const { crate, removeFromCrate, clearCrate } = useContext(CrateContext);
+  const { token } = useContext(AuthContext);
+  const [showModal, setShowModal] = useState(false);
+
+  const handleConfirm = async (name) => {
+    try {
+      const profile = await getProfile(token);
+      const playlist = await createPlaylist(token, profile.id, name);
+      await addTracksToPlaylist(
+        token,
+        playlist.id,
+        crate.map((t) => t.uri)
+      );
+      clearCrate();
+      setShowModal(false);
+      alert('Playlist created!');
+    } catch (e) {
+      console.error(e);
+      alert('Failed to create playlist');
+    }
+  };
+
+  return (
+    <div className="p-10">
+      <Crate
+        crate={crate}
+        onRemove={removeFromCrate}
+        onProceed={() => setShowModal(true)}
+      />
+      {showModal && (
+        <PlaylistModal
+          onConfirm={handleConfirm}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CrateView;

--- a/src/components/FlippableAlbum.jsx
+++ b/src/components/FlippableAlbum.jsx
@@ -5,6 +5,7 @@ export default function FlippableAlbum({
   flipped: flippedProp,
   onToggle,
   onAddToCrate = () => {},
+  onAddToShelf = () => {},
   onGenreClick = () => {},
 }) {
   const [internalFlipped, setInternalFlipped] = useState(false);
@@ -19,6 +20,11 @@ export default function FlippableAlbum({
   const handleAdd = (e) => {
     e.stopPropagation();
     onAddToCrate(song);
+  };
+
+  const handleAddShelf = (e) => {
+    e.stopPropagation();
+    onAddToShelf(song);
   };
 
   const handleToggle = () => {
@@ -58,9 +64,14 @@ export default function FlippableAlbum({
               ))}
             </div>
           </div>
-          <button onClick={handleAdd} className="bg-purple-600 hover:bg-purple-700 text-white px-2 py-1 rounded mt-2">
-            Add to Crate
-          </button>
+          <div className="flex gap-2 mt-2">
+            <button onClick={handleAdd} className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded">
+              Add to Crate
+            </button>
+            <button onClick={handleAddShelf} className="bg-purple-600 hover:bg-purple-700 text-white px-2 py-1 rounded">
+              Add to Shelf
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/RecordPlayerModel.jsx
+++ b/src/components/RecordPlayerModel.jsx
@@ -47,7 +47,7 @@ function Vinyl({ album, playing, lifted, onGenreSelect }) {
 export default function RecordPlayerModel({ album, playing, lifted, onGenreSelect }) {
   const knobRef = useRef();
   const [knob, setKnob] = useState(0);
-  // blue base block for the player
+  // base block for the player
   const dragging = useRef(false);
 
   useFrame(() => {
@@ -73,7 +73,7 @@ export default function RecordPlayerModel({ album, playing, lifted, onGenreSelec
     <group>
       <mesh position={[0, -1.5, 0]} receiveShadow>
         <boxGeometry args={[4, 0.3, 4]} />
-        <meshStandardMaterial color="blue" />
+        <meshStandardMaterial color="#7b5237" />
       </mesh>
       <mesh receiveShadow castShadow>
         <boxGeometry args={[3, 0.3, 2]} />

--- a/src/components/RecordStoreEnvironment.jsx
+++ b/src/components/RecordStoreEnvironment.jsx
@@ -22,24 +22,24 @@ export default function RecordStoreEnvironment() {
   const records = mockSongs.slice(0, 4);
   return (
     <group>
-      <Environment preset="warehouse" />
+      <Environment preset="dawn" />
       {/* Floor */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -2.2, 0]} receiveShadow>
         <planeGeometry args={[20, 20]} />
-        <meshStandardMaterial color="#777" />
+        <meshStandardMaterial color="#554433" />
       </mesh>
       {/* Walls */}
       <mesh position={[0, 2, -10]} receiveShadow>
         <boxGeometry args={[20, 8, 0.1]} />
-        <meshStandardMaterial color="#999" />
+        <meshStandardMaterial color="#777" />
       </mesh>
       <mesh position={[-10, 2, 0]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
         <boxGeometry args={[20, 8, 0.1]} />
-        <meshStandardMaterial color="#999" />
+        <meshStandardMaterial color="#777" />
       </mesh>
       <mesh position={[10, 2, 0]} rotation={[0, -Math.PI / 2, 0]} receiveShadow>
         <boxGeometry args={[20, 8, 0.1]} />
-        <meshStandardMaterial color="#999" />
+        <meshStandardMaterial color="#777" />
       </mesh>
       {/* Table */}
       <mesh position={[0, -1.9, 0]} receiveShadow castShadow>

--- a/src/components/SwipeView.jsx
+++ b/src/components/SwipeView.jsx
@@ -1,29 +1,47 @@
 import React, { useEffect, useContext, useState } from 'react';
+import VinylPlayer from './VinylPlayer.jsx';
 import { AuthContext } from '../contexts/AuthContext.jsx';
+import { CrateContext } from '../contexts/CrateContext.jsx';
+import { ShelfContext } from '../contexts/ShelfContext.jsx';
 import { getRecommendations, getRecommendationsByGenre } from '../SpotifyService.js';
-import VinylCard from './VinylCard.jsx';
 
 const SwipeView = () => {
   const { token } = useContext(AuthContext);
-  const [tracks, setTracks] = useState([]);
+  const { addToCrate } = useContext(CrateContext);
+  const { addToShelf } = useContext(ShelfContext);
+  const [track, setTrack] = useState(null);
   const [genre, setGenre] = useState(null);
 
   useEffect(() => {
     if (!token) return;
     if (genre) {
-      getRecommendationsByGenre(token, genre).then((data) => setTracks(data.tracks));
+      getRecommendationsByGenre(token, genre).then((data) => {
+        if (data.tracks.length > 0) setTrack(data.tracks[0]);
+      });
     } else {
       const seed = '4uLU6hMCjMI75M1A2tKUQC';
-      getRecommendations(token, seed).then((data) => setTracks(data.tracks));
+      getRecommendations(token, seed).then((data) => {
+        if (data.tracks.length > 0) setTrack(data.tracks[0]);
+      });
     }
   }, [token, genre]);
 
+  if (!track) return <div className="text-white p-10">Loading...</div>;
+
   return (
-    <div className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      {tracks.map((track) => (
-        <VinylCard key={track.id} track={track} onGenreSelect={(g) => setGenre(g)} />
-      ))}
-    </div>
+    <VinylPlayer
+      song={{
+        title: track.name,
+        artist: track.artists[0].name,
+        genre: [],
+        bio: '',
+        image: track.album.images[0]?.url,
+        preview_url: track.preview_url,
+      }}
+      onGenreSelect={(g) => setGenre(g)}
+      onAddToCrate={() => addToCrate(track)}
+      onAddToShelf={() => addToShelf(track)}
+    />
   );
 };
 

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -8,13 +8,19 @@ import ControlOverlay from './ControlOverlay.jsx';
 export default function ThreeDRecordPlayer({
   album,
   onAddToCrate = () => {},
+  onAddToShelf = () => {},
   onGenreSelect = () => {},
   onInfoToggle = () => {},
+  onPlayAudio = () => {},
+  playing: playingProp,
   className = '',
 }) {
-  const [playing, setPlaying] = useState(false);
+  const [internalPlaying, setInternalPlaying] = useState(false);
   const [lifted, setLifted] = useState(false);
   const timerRef = useRef(null);
+
+  const playing = playingProp !== undefined ? playingProp : internalPlaying;
+  const setPlaying = playingProp !== undefined ? () => {} : setInternalPlaying;
 
   useEffect(() => {
     return () => timerRef.current && clearTimeout(timerRef.current);
@@ -24,8 +30,10 @@ export default function ThreeDRecordPlayer({
     if (!playing) {
       setLifted(true);
       timerRef.current = setTimeout(() => setPlaying(true), 600);
+      onPlayAudio();
     } else {
       setPlaying(false);
+      onPlayAudio();
     }
   };
   const handleView = () => setLifted((v) => !v);
@@ -33,8 +41,9 @@ export default function ThreeDRecordPlayer({
   return (
     <div className={`${className} w-screen h-[80vh]`}>
       <Canvas shadows camera={{ position: [0, 5, 8], fov: 50 }}>
-        <ambientLight intensity={0.4} />
-        <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
+        <ambientLight intensity={0.3} color="#ffdda8" />
+        <pointLight position={[2, 4, 2]} intensity={0.6} color="#ffcc88" castShadow />
+        <directionalLight position={[-5, 8, 5]} intensity={0.4} color="#ffae66" castShadow />
         <RecordStoreEnvironment />
         <RecordPlayerModel
           album={album}
@@ -47,7 +56,8 @@ export default function ThreeDRecordPlayer({
           onPlayPause={togglePlay}
           onView={handleView}
           onInfo={onInfoToggle}
-          onAdd={() => onAddToCrate(album)}
+          onAddCrate={() => onAddToCrate(album)}
+          onAddShelf={() => onAddToShelf(album)}
         />
         <OrbitControls enablePan={false} />
       </Canvas>

--- a/src/components/VinylPlayer.jsx
+++ b/src/components/VinylPlayer.jsx
@@ -1,10 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import ThreeDRecordPlayer from './ThreeDRecordPlayer.jsx';
 import AlbumInfoPopup from './AlbumInfoPopup.jsx';
 import FlippableAlbum from './FlippableAlbum.jsx';
 
-export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
+export default function VinylPlayer({ song, onGenreSelect, onAddToCrate, onAddToShelf }) {
   const [infoOpen, setInfoOpen] = useState(false);
+  const audioRef = useRef(null);
+  const [playing, setPlaying] = useState(false);
+
+  const handlePlayPause = () => {
+    if (!audioRef.current) return;
+    if (playing) {
+      audioRef.current.pause();
+      setPlaying(false);
+    } else {
+      audioRef.current.play();
+      setPlaying(true);
+    }
+  };
   return (
     <div className="flex flex-col md:flex-row items-center justify-center gap-6 p-4 h-screen w-full">
       <div className="w-full h-full">
@@ -20,6 +33,9 @@ export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
           onGenreSelect={onGenreSelect}
           onInfoToggle={() => setInfoOpen((o) => !o)}
           onAddToCrate={() => onAddToCrate(song)}
+          onAddToShelf={() => onAddToShelf(song)}
+          onPlayAudio={handlePlayPause}
+          playing={playing}
         />
       </div>
 
@@ -29,6 +45,7 @@ export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
           flipped={infoOpen}
           onToggle={() => setInfoOpen((o) => !o)}
           onAddToCrate={onAddToCrate}
+          onAddToShelf={onAddToShelf}
           onGenreClick={onGenreSelect}
         />
       </div>
@@ -38,6 +55,9 @@ export default function VinylPlayer({ song, onGenreSelect, onAddToCrate }) {
         onClose={() => setInfoOpen(false)}
         onGenreClick={onGenreSelect}
       />
+      {song.preview_url && (
+        <audio ref={audioRef} src={song.preview_url} onEnded={() => setPlaying(false)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- route app through login and protected views
- warm up 3D environment lighting and materials
- play audio previews and add shelf/crate actions
- fetch one track at a time from Spotify
- allow creating playlists from crate

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68474987cc18832fb47b44e6e54bef66