### PR TITLE
Add Spotify token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ npm install
 npm run dev
 ```
 
+### Spotify Credentials
+
+Create a `.env` file at the project root with your Spotify app credentials:
+
+```
+REACT_APP_SPOTIFY_CLIENT_ID=<your client id>
+SPOTIFY_CLIENT_SECRET=<your client secret>
+REACT_APP_REDIRECT_URI=https://vinylswipe.netlify.app/callback
+VITE_SPOTIFY_CLIENT_ID=<your client id>
+VITE_REDIRECT_URI=https://vinylswipe.netlify.app/callback
+```
+
+When running the Vite dev server directly, set `VITE_FUNCTIONS_BASE` to the URL
+where your Netlify functions are served (e.g. `http://localhost:8888`).
+
 If `npm run build` fails with a message like `Cannot find module @rollup/rollup-linux-x64-gnu`,
 remove `node_modules` and `package-lock.json` then reinstall to ensure the correct
 Rollup binary is downloaded for your platform:


### PR DESCRIPTION
## Summary
- automatically refresh Spotify auth tokens
- document .env format for Spotify credentials

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684756a7218c832f9aaa1bf8875123fe