### PR TITLE
Add demo option on login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import ProtectedRoute from './components/ProtectedRoute.jsx';
 import SwipeView from './components/SwipeView.jsx';
 import Shelf from './components/Shelf.jsx';
 import CrateView from './components/CrateView.jsx';
+import DemoApp from './DemoApp.jsx';
 
 export default function App() {
   return (
@@ -18,6 +19,7 @@ export default function App() {
           <ShelfProvider>
             <Routes>
               <Route path="/" element={<Login />} />
+              <Route path="/demo" element={<DemoApp />} />
               <Route path="/callback" element={<Callback />} />
               <Route
                 path="/swipe"

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 // Vite exposes environment variables via `import.meta.env`.
 // Fall back to the old REACT_APP_ names for compatibility with
@@ -21,10 +22,19 @@ const Login = () => {
   };
 
   return (
-    <div className="flex items-center justify-center h-screen bg-black text-white">
-      <button onClick={handleLogin} className="bg-green-500 px-6 py-3 rounded-xl text-xl font-bold">
+    <div className="flex flex-col items-center justify-center gap-4 h-screen bg-black text-white">
+      <button
+        onClick={handleLogin}
+        className="bg-green-500 px-6 py-3 rounded-xl text-xl font-bold"
+      >
         Login with Spotify
       </button>
+      <Link
+        to="/demo"
+        className="bg-blue-600 px-6 py-3 rounded-xl text-xl font-bold"
+      >
+        Demo
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add link to a demo version from the login screen
- route `/demo` to the mock data demo

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68483fa60df0832fac64e6950cf3e7ff