### PR TITLE
Add interactive wall shelf and record animation

### DIFF
--- a/src/components/FlyingAlbum.jsx
+++ b/src/components/FlyingAlbum.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTexture } from '@react-three/drei';
+import { useSpring, animated } from '@react-spring/three';
+
+export default function FlyingAlbum({ album, from, to, onEnd }) {
+  const texture = useTexture(album.image);
+  const { pos } = useSpring({
+    from: { pos: from },
+    to: { pos: to },
+    config: { mass: 1, tension: 120, friction: 20 },
+    onRest: onEnd,
+  });
+  return (
+    <animated.mesh position={pos} castShadow>
+      <planeGeometry args={[1, 1]} />
+      <meshBasicMaterial map={texture} />
+    </animated.mesh>
+  );
+}

--- a/src/components/RecordPlayerModel.jsx
+++ b/src/components/RecordPlayerModel.jsx
@@ -47,6 +47,10 @@ function Vinyl({ album, playing, lifted, onGenreSelect }) {
 export default function RecordPlayerModel({ album, playing, lifted, onGenreSelect }) {
   const knobRef = useRef();
   const [knob, setKnob] = useState(0);
+  const { rotation: toneRotation } = useSpring({
+    rotation: playing && lifted ? [0, 0, -0.5] : [0, 0, -0.3],
+    config: { mass: 1, tension: 120, friction: 14 },
+  });
   // base block for the player
   const dragging = useRef(false);
 
@@ -83,10 +87,14 @@ export default function RecordPlayerModel({ album, playing, lifted, onGenreSelec
         <cylinderGeometry args={[1.6, 1.6, 0.1, 64]} />
         <meshStandardMaterial color="#888" metalness={1} roughness={0.4} />
       </mesh>
-      <mesh position={[-0.8, 0.05, 0.8]} rotation={[0, 0, -0.3]} castShadow>
+      <animated.mesh
+        position={[-0.8, 0.05, 0.8]}
+        rotation={toneRotation}
+        castShadow
+      >
         <cylinderGeometry args={[0.02, 0.02, 1.2, 16]} />
         <meshStandardMaterial color="#b0b0b0" metalness={1} roughness={0.3} />
-      </mesh>
+      </animated.mesh>
       <mesh
         ref={knobRef}
         position={[1, 0.2, 0.8]}

--- a/src/components/RecordStoreEnvironment.jsx
+++ b/src/components/RecordStoreEnvironment.jsx
@@ -1,24 +1,10 @@
 import React from 'react';
-import { useTexture, Environment } from '@react-three/drei';
+import { Environment } from '@react-three/drei';
 import { mockSongs } from '../data/mockSongs.js';
+import WallShelf from './WallShelf.jsx';
 
-function VinylRecord({ image, position }) {
-  const texture = useTexture(image);
-  return (
-    <group position={position} rotation={[-Math.PI / 2, 0, 0]}>
-      <mesh receiveShadow castShadow>
-        <cylinderGeometry args={[0.6, 0.6, 0.02, 32]} />
-        <meshStandardMaterial color="black" />
-      </mesh>
-      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.011, 0]}>
-        <circleGeometry args={[0.3, 32]} />
-        <meshBasicMaterial map={texture} />
-      </mesh>
-    </group>
-  );
-}
 
-export default function RecordStoreEnvironment() {
+export default function RecordStoreEnvironment({ onSelectAlbum }) {
   const records = mockSongs.slice(0, 4);
   return (
     <group>
@@ -41,24 +27,13 @@ export default function RecordStoreEnvironment() {
         <boxGeometry args={[20, 8, 0.1]} />
         <meshStandardMaterial color="#777" />
       </mesh>
-      {/* Table */}
-      <mesh position={[0, -1.9, 0]} receiveShadow castShadow>
-        <boxGeometry args={[6, 0.3, 4]} />
-        <meshStandardMaterial color="#654321" />
+      {/* Shelf supporting the record player */}
+      <mesh position={[0, -1.65, -9.6]} receiveShadow castShadow>
+        <boxGeometry args={[6, 0.2, 2.5]} />
+        <meshStandardMaterial color="#7b5237" />
       </mesh>
-      {/* Simple Shelves */}
-      <mesh position={[-3, 0, -3]} receiveShadow>
-        <boxGeometry args={[0.4, 2, 6]} />
-        <meshStandardMaterial color="#444" />
-      </mesh>
-      <mesh position={[3, 0, -3]} receiveShadow>
-        <boxGeometry args={[0.4, 2, 6]} />
-        <meshStandardMaterial color="#444" />
-      </mesh>
-      {/* Records */}
-      {records.map((song, idx) => (
-        <VinylRecord key={song.id} image={song.image} position={[-1.5 + idx, -1.85, 1]} />
-      ))}
+      {/* Wall shelf of albums */}
+      <WallShelf albums={records} onSelect={onSelectAlbum} />
     </group>
   );
 }

--- a/src/components/WallShelf.jsx
+++ b/src/components/WallShelf.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useTexture, Html } from '@react-three/drei';
+
+function Album({ album, position, onClick }) {
+  const texture = useTexture(album.image);
+  return (
+    <group position={position}>
+      <mesh onClick={onClick} castShadow>
+        <planeGeometry args={[1, 1]} />
+        <meshBasicMaterial map={texture} />
+      </mesh>
+      <Html distanceFactor={3} position={[0, -0.8, 0]} style={{ pointerEvents: 'none' }}>
+        <div className="text-xs text-white bg-black bg-opacity-60 px-1 rounded">
+          {album.title} - {album.artist}
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+export default function WallShelf({ albums = [], onSelect }) {
+  return (
+    <group position={[0, 0, -9.6]}>
+      <mesh position={[0, -1.6, 0]} receiveShadow castShadow>
+        <boxGeometry args={[6, 0.2, 2]} />
+        <meshStandardMaterial color="#7b5237" />
+      </mesh>
+      <mesh position={[0, 0.4, -0.05]} receiveShadow>
+        <boxGeometry args={[6, 3.5, 0.1]} />
+        <meshStandardMaterial color="#333" />
+      </mesh>
+      {albums.map((album, idx) => {
+        const x = -2.5 + (idx % 4) * 1.7;
+        const y = 1.3 - Math.floor(idx / 4) * 1.7;
+        return (
+          <Album
+            key={album.id}
+            album={album}
+            position={[x, y, 0.06]}
+            onClick={() => onSelect && onSelect(album, [x, y, -9.54])}
+          />
+        );
+      })}
+    </group>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `WallShelf` for clickable albums
- animate album movement with `FlyingAlbum`
- mount player on back wall shelf in `RecordStoreEnvironment`
- add playback animation when a record is selected in `ThreeDRecordPlayer`
- animate tonearm in `RecordPlayerModel`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68484285453c832f918b08bc9609cbdb