### PR TITLE
Adjust environment layout

### DIFF
--- a/src/components/RecordStoreEnvironment.jsx
+++ b/src/components/RecordStoreEnvironment.jsx
@@ -5,7 +5,7 @@ import WallShelf from './WallShelf.jsx';
 
 
 export default function RecordStoreEnvironment({ onSelectAlbum }) {
-  const records = mockSongs.slice(0, 4);
+  const records = mockSongs;
   return (
     <group>
       <Environment preset="dawn" />
@@ -28,7 +28,7 @@ export default function RecordStoreEnvironment({ onSelectAlbum }) {
         <meshStandardMaterial color="#777" />
       </mesh>
       {/* Shelf supporting the record player */}
-      <mesh position={[0, -1.65, -9.6]} receiveShadow castShadow>
+      <mesh position={[0, -1.65, -8.5]} receiveShadow castShadow>
         <boxGeometry args={[6, 0.2, 2.5]} />
         <meshStandardMaterial color="#7b5237" />
       </mesh>

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -69,11 +69,11 @@ export default function ThreeDRecordPlayer({
           <FlyingAlbum
             album={flying.album}
             from={flying.from}
-            to={[0, 1.5, -10.6]}
+            to={[0, 1.5, -9.5]}
             onEnd={handleFlyEnd}
           />
         )}
-        <group position={[0, 0, -9.6]}>
+        <group position={[0, 0, -8.5]}>
           <RecordPlayerModel
             album={currentAlbum}
             playing={playing}

--- a/src/components/WallShelf.jsx
+++ b/src/components/WallShelf.jsx
@@ -19,22 +19,33 @@ function Album({ album, position, onClick }) {
 }
 
 export default function WallShelf({ albums = [], onSelect }) {
+  const boardWidth = 18;
+  const boardHeight = 3.5;
+  const rows = 2;
+  const perRow = 10;
+  const total = rows * perRow;
+  const extended = Array.from({ length: total }, (_, i) => albums[i % albums.length]);
+  const xStep = boardWidth / perRow;
+  const yStep = 1.7;
+  const xStart = -boardWidth / 2 + xStep / 2;
+  const yStart = 1.3;
+
   return (
     <group position={[0, 0, -9.6]}>
       <mesh position={[0, -1.6, 0]} receiveShadow castShadow>
-        <boxGeometry args={[6, 0.2, 2]} />
+        <boxGeometry args={[boardWidth, 0.2, 2]} />
         <meshStandardMaterial color="#7b5237" />
       </mesh>
       <mesh position={[0, 0.4, -0.05]} receiveShadow>
-        <boxGeometry args={[6, 3.5, 0.1]} />
+        <boxGeometry args={[boardWidth, boardHeight, 0.1]} />
         <meshStandardMaterial color="#333" />
       </mesh>
-      {albums.map((album, idx) => {
-        const x = -2.5 + (idx % 4) * 1.7;
-        const y = 1.3 - Math.floor(idx / 4) * 1.7;
+      {extended.map((album, idx) => {
+        const x = xStart + (idx % perRow) * xStep;
+        const y = yStart - Math.floor(idx / perRow) * yStep;
         return (
           <Album
-            key={album.id}
+            key={`${album.id}-${idx}`}
             album={album}
             position={[x, y, 0.06]}
             onClick={() => onSelect && onSelect(album, [x, y, -9.54])}


### PR DESCRIPTION
## Summary
- move record player shelf forward from the wall
- expand wall shelf to span almost the whole wall
- keep albums clickable and duplicated to fill the space

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68484548985c832fa5834ca67398d7f1