### PR TITLE
Fix flying album animation

### DIFF
--- a/src/components/FlyingAlbum.jsx
+++ b/src/components/FlyingAlbum.jsx
@@ -6,7 +6,10 @@ export default function FlyingAlbum({ album, from, to, onEnd }) {
   const texture = useTexture(album.image);
   const { pos } = useSpring({
     from: { pos: from },
-    to: { pos: to },
+    to: async (next) => {
+      await next({ pos: [from[0], from[1], from[2] + 0.5] });
+      await next({ pos: to });
+    },
     config: { mass: 1, tension: 120, friction: 20 },
     onRest: onEnd,
   });

--- a/src/components/RecordStoreEnvironment.jsx
+++ b/src/components/RecordStoreEnvironment.jsx
@@ -4,7 +4,7 @@ import { mockSongs } from '../data/mockSongs.js';
 import WallShelf from './WallShelf.jsx';
 
 
-export default function RecordStoreEnvironment({ onSelectAlbum }) {
+export default function RecordStoreEnvironment({ onSelectAlbum, hiddenIndex }) {
   const records = mockSongs;
   return (
     <group>
@@ -33,7 +33,7 @@ export default function RecordStoreEnvironment({ onSelectAlbum }) {
         <meshStandardMaterial color="#7b5237" />
       </mesh>
       {/* Wall shelf of albums */}
-      <WallShelf albums={records} onSelect={onSelectAlbum} />
+      <WallShelf albums={records} onSelect={onSelectAlbum} hiddenIndex={hiddenIndex} />
     </group>
   );
 }

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -20,6 +20,7 @@ export default function ThreeDRecordPlayer({
   const [lifted, setLifted] = useState(false);
   const [currentAlbum, setCurrentAlbum] = useState(album);
   const [flying, setFlying] = useState(null);
+  const [hiddenIdx, setHiddenIdx] = useState(null);
   const timerRef = useRef(null);
 
   const playing = playingProp !== undefined ? playingProp : internalPlaying;
@@ -44,14 +45,16 @@ export default function ThreeDRecordPlayer({
     }
   };
   const handleView = () => setLifted((v) => !v);
-  const handleAlbumSelect = (a, pos) => {
+  const handleAlbumSelect = (a, pos, idx) => {
     setFlying({ album: a, from: pos });
+    setHiddenIdx(idx);
   };
 
   const handleFlyEnd = () => {
     if (flying) {
       setCurrentAlbum(flying.album);
       setFlying(null);
+      setHiddenIdx(null);
       setLifted(true);
       timerRef.current = setTimeout(() => setPlaying(true), 600);
       onPlayAudio();
@@ -64,7 +67,7 @@ export default function ThreeDRecordPlayer({
         <ambientLight intensity={0.3} color="#ffdda8" />
         <pointLight position={[2, 4, 2]} intensity={0.6} color="#ffcc88" castShadow />
         <directionalLight position={[-5, 8, 5]} intensity={0.4} color="#ffae66" castShadow />
-        <RecordStoreEnvironment onSelectAlbum={handleAlbumSelect} />
+        <RecordStoreEnvironment onSelectAlbum={handleAlbumSelect} hiddenIndex={hiddenIdx} />
         {flying && (
           <FlyingAlbum
             album={flying.album}
@@ -73,7 +76,7 @@ export default function ThreeDRecordPlayer({
             onEnd={handleFlyEnd}
           />
         )}
-        <group position={[0, 0, -8.5]}>
+        <group position={[0, 0.1, -8.5]}>
           <RecordPlayerModel
             album={currentAlbum}
             playing={playing}

--- a/src/components/WallShelf.jsx
+++ b/src/components/WallShelf.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useTexture, Html } from '@react-three/drei';
 
-function Album({ album, position, onClick }) {
+function Album({ album, position, onClick, hidden }) {
+  if (hidden) return null;
   const texture = useTexture(album.image);
   return (
     <group position={position}>
@@ -18,7 +19,7 @@ function Album({ album, position, onClick }) {
   );
 }
 
-export default function WallShelf({ albums = [], onSelect }) {
+export default function WallShelf({ albums = [], onSelect, hiddenIndex }) {
   const boardWidth = 18;
   const boardHeight = 3.5;
   const rows = 2;
@@ -48,7 +49,8 @@ export default function WallShelf({ albums = [], onSelect }) {
             key={`${album.id}-${idx}`}
             album={album}
             position={[x, y, 0.06]}
-            onClick={() => onSelect && onSelect(album, [x, y, -9.54])}
+            onClick={() => onSelect && onSelect(album, [x, y, -9.54], idx)}
+            hidden={idx === hiddenIndex}
           />
         );
       })}


### PR DESCRIPTION
## Summary
- animate album popping off wall before moving to the player
- hide album on the wall while it is flying
- raise record player so it rests flush on the shelf

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68484ad0397c832f85a32cae1e81b162