### PR TITLE
Update record player position

### DIFF
--- a/src/components/RecordStoreEnvironment.jsx
+++ b/src/components/RecordStoreEnvironment.jsx
@@ -28,7 +28,7 @@ export default function RecordStoreEnvironment({ onSelectAlbum, hiddenIndex }) {
         <meshStandardMaterial color="#777" />
       </mesh>
       {/* Shelf supporting the record player */}
-      <mesh position={[0, -1.65, -8.5]} receiveShadow castShadow>
+      <mesh position={[0, -1.95, -8.2]} receiveShadow castShadow>
         <boxGeometry args={[6, 0.2, 2.5]} />
         <meshStandardMaterial color="#7b5237" />
       </mesh>

--- a/src/components/ThreeDRecordPlayer.jsx
+++ b/src/components/ThreeDRecordPlayer.jsx
@@ -79,11 +79,11 @@ export default function ThreeDRecordPlayer({
           <FlyingAlbum
             album={flying.album}
             from={flying.from}
-            to={[0, 1.5, -9.5]}
+            to={[0, 1.5, -9.2]}
             onEnd={handleFlyEnd}
           />
         )}
-        <group position={[0, 0.1, -8.5]}>
+        <group position={[0, -0.2, -8.2]}>
           <RecordPlayerModel
             album={currentAlbum}
             playing={playing}


### PR DESCRIPTION
## Summary
- adjust flying album target to line up with new player location
- shift record player group forward and downward
- reposition shelf supporting the player

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68484d78bdec832f9138a2d97f774434